### PR TITLE
post_message時にオプションを追加できるようにする

### DIFF
--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -38,7 +38,7 @@ module Capistrano
         'text'       => announcement,
         'icon_emoji' => slack_emoji,
         'mrkdwn'     => true
-      }.to_json
+      }.merge(slack_post_message_option.stringify_keys).to_json
     end
 
     def attachment_payload(color, announcement)

--- a/lib/capistrano/slack_notify.rb
+++ b/lib/capistrano/slack_notify.rb
@@ -52,7 +52,7 @@ module Capistrano
           'color'     => HEX_COLORS[color],
           'mrkdwn_in' => %w{text}
         }]
-      }.to_json
+      }.merge(slack_post_message_option.stringify_keys).to_json
     end
 
     def use_color?
@@ -93,6 +93,10 @@ module Capistrano
 
     def slack_deploy_target
       [slack_app_name, branch].join('/')
+    end
+
+    def slack_post_message_option
+      fetch(:slack_post_message_option, {})
     end
 
     def self.extended(configuration)


### PR DESCRIPTION
capistranoのコンフィグで

```
set :slack_post_message_option, 'link_names' => 1
```

などが利用できるようにする修正です。
